### PR TITLE
feat/limit amount of warehouses that a person can create by time

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -9,7 +9,7 @@ const config: UserConfig = {
       ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test']
     ],
     'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
-    'header-max-length': [2, 'always', 72]
+    'header-max-length': [2, 'always', 150]
   }
 }
 

--- a/src/app/[locale]/map/components/CreateWarehouseForm.tsx
+++ b/src/app/[locale]/map/components/CreateWarehouseForm.tsx
@@ -45,7 +45,6 @@ export const CreateWarehouseForm = ({ location, onClose }: CreateWarehouseFormPr
   const onSubmit = async (data: CreateWarehouseFormData) => {
     setIsSubmitting(true)
     const toasterId = toaster.loading('Creando almacén...')
-    console.dir({ method: 'onSubmit', data, location }, { depth: null })
 
     const result = await createWarehouse(data)
     if (result.success) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,3 +4,7 @@ export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || ''
 
 export const API_BASE = '/api'
 export const WAREHOUSE_API_URI = API_BASE.concat('/warehouse')
+
+export const NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY = Number(
+  process.env.NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY || '1'
+)

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,4 @@ export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || ''
 export const API_BASE = '/api'
 export const WAREHOUSE_API_URI = API_BASE.concat('/warehouse')
 
-export const NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY = Number(
-  process.env.NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY || '1'
-)
+export const MAX_AMOUNT_OF_WAREHOUSES_PER_DAY = Number(process.env.NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY || '1')

--- a/src/modules/warehouse/errors/400.bad.request/MaximumAmountOfCreatedWarehousesReachedError.ts
+++ b/src/modules/warehouse/errors/400.bad.request/MaximumAmountOfCreatedWarehousesReachedError.ts
@@ -1,0 +1,11 @@
+import { CustomApiError } from '@modules/core/errors'
+import { StatusCodes } from 'http-status-codes'
+
+const statusCode = StatusCodes.BAD_REQUEST
+const message = 'You cannot create more warehouses today'
+
+export class MaximumAmountOfCreatedWarehousesReachedError extends CustomApiError {
+  constructor(description?: CustomApiError['description']) {
+    super(statusCode, message, description)
+  }
+}

--- a/src/modules/warehouse/errors/400.bad.request/index.ts
+++ b/src/modules/warehouse/errors/400.bad.request/index.ts
@@ -1,0 +1,1 @@
+export * from './MaximumAmountOfCreatedWarehousesReachedError'

--- a/src/modules/warehouse/errors/index.ts
+++ b/src/modules/warehouse/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './400.bad.request'

--- a/src/modules/warehouse/hooks/useWarehouses.ts
+++ b/src/modules/warehouse/hooks/useWarehouses.ts
@@ -17,17 +17,17 @@ export const useWarehouses = () => {
     try {
       const result = await createWarehouse(payload)
 
-      if (!result.success) throw new Error(result.result.toString())
-
-      mutate(
-        WAREHOUSES_KEY,
-        {
-          result: {
-            warehouses: [...((data?.result.warehouses as Array<Warehouse>) || []), result.result]
-          }
-        },
-        false
-      )
+      if (result.success) {
+        mutate(
+          WAREHOUSES_KEY,
+          {
+            result: {
+              warehouses: [...((data?.result.warehouses as Array<Warehouse>) || []), result.result]
+            }
+          },
+          false
+        )
+      }
 
       return result
     } catch (error) {

--- a/src/modules/warehouse/warehouse.controller.ts
+++ b/src/modules/warehouse/warehouse.controller.ts
@@ -1,4 +1,4 @@
-import { NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY } from '@config'
+import { MAX_AMOUNT_OF_WAREHOUSES_PER_DAY } from '@config'
 import { Warehouse } from '@modules/warehouse/warehouse.model'
 import { WarehouseRepository } from '@modules/warehouse/warehouse.repository'
 import { randomUUID } from 'crypto'
@@ -9,7 +9,7 @@ const throwErrorIfUserCannotCreateMoreWarehousesToday = async (userId: string): 
   const end = new Date(new Date().setHours(23, 59, 59, 0))
 
   const warehousesCreatedToday = await WarehouseRepository.getWarehousesCreatedTodayByUserId({ userId, start, end })
-  if (warehousesCreatedToday.length >= NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY) {
+  if (warehousesCreatedToday.length >= MAX_AMOUNT_OF_WAREHOUSES_PER_DAY) {
     // TODO: Throw a correctly formatted error
     throw new MaximumAmountOfCreatedWarehousesReachedError()
   }

--- a/src/modules/warehouse/warehouse.controller.ts
+++ b/src/modules/warehouse/warehouse.controller.ts
@@ -1,15 +1,17 @@
+import { NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY } from '@config'
 import { Warehouse } from '@modules/warehouse/warehouse.model'
 import { WarehouseRepository } from '@modules/warehouse/warehouse.repository'
 import { randomUUID } from 'crypto'
+import { MaximumAmountOfCreatedWarehousesReachedError } from './errors'
 
-const throwErrorIfUserHasCreatedWarehouseToday = async (userId: string): Promise<void> => {
+const throwErrorIfUserCannotCreateMoreWarehousesToday = async (userId: string): Promise<void> => {
   const start = new Date(new Date().setHours(0, 0, 0, 0))
   const end = new Date(new Date().setHours(23, 59, 59, 0))
 
   const warehousesCreatedToday = await WarehouseRepository.getWarehousesCreatedTodayByUserId({ userId, start, end })
-  if (warehousesCreatedToday.length) {
+  if (warehousesCreatedToday.length >= NEXT_PUBLIC_MAX_AMOUNT_OF_WAREHOUSES_PER_DAY) {
     // TODO: Throw a correctly formatted error
-    throw new Error('Ya has creado un almacén hoy')
+    throw new MaximumAmountOfCreatedWarehousesReachedError()
   }
 }
 
@@ -54,7 +56,7 @@ interface CreateWarehouseProps {
 const createWarehouse = async ({ name, lat, lng, userId }: CreateWarehouseProps): Promise<Warehouse> => {
   console.dir({ name, lat, lng, userId }, { depth: null })
 
-  await throwErrorIfUserHasCreatedWarehouseToday(userId)
+  await throwErrorIfUserCannotCreateMoreWarehousesToday(userId)
   await throwErrorIfThereAreOtherWarehousesNearby({ lat, lng })
 
   try {
@@ -96,152 +98,7 @@ const createWarehouse = async ({ name, lat, lng, userId }: CreateWarehouseProps)
 //   } as Warehouse
 // }
 
-const getWarehouses = async (): Promise<Array<Warehouse>> => {
-  // return await WarehouseRepository.getWarehouses()
-
-  return Promise.resolve([
-    {
-      id: '1',
-      code: 'PAI',
-      name: 'Almacén Paiporta Principal',
-      location: {
-        lat: 39.4286,
-        lng: -0.4175,
-        address: 'Polígono Industrial La Pascualeta, Paiporta'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01')
-    },
-    {
-      id: '2',
-      code: 'CAT',
-      name: 'Centro Logístico Catarroja',
-      location: {
-        lat: 39.4036,
-        lng: -0.4027,
-        address: 'Polígono Industrial El Bony, Catarroja'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-02'),
-      updatedAt: new Date('2024-01-02')
-    },
-    {
-      id: '3',
-      code: 'ALF',
-      name: 'Almacén Alfafar',
-      location: {
-        lat: 39.4225,
-        lng: -0.3775,
-        address: 'Polígono Industrial Rabisancho, Alfafar'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-03'),
-      updatedAt: new Date('2024-01-03')
-    },
-    {
-      id: '4',
-      code: 'SED',
-      name: 'Centro Distribución Sedaví',
-      location: {
-        lat: 39.4256,
-        lng: -0.3839,
-        address: 'Polígono Industrial Sedaví, Av. del Mediterráneo'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-04'),
-      updatedAt: new Date('2024-01-04')
-    },
-    {
-      id: '5',
-      code: 'ALB',
-      name: 'Almacén Albal Norte',
-      location: {
-        lat: 39.3947,
-        lng: -0.4119,
-        address: 'Polígono Industrial Juan Peris, Albal'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-05'),
-      updatedAt: new Date('2024-01-05')
-    },
-    {
-      id: '6',
-      code: 'TOR',
-      name: 'Logística Torrent Mas del Jutge',
-      location: {
-        lat: 39.432,
-        lng: -0.4477,
-        address: 'Polígono Industrial Mas del Jutge, Torrent'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-06'),
-      updatedAt: new Date('2024-01-06')
-    },
-    {
-      id: '7',
-      code: 'TO2',
-      name: 'Centro Logístico Torrent Sur',
-      location: {
-        lat: 39.4173,
-        lng: -0.4594,
-        address: "Polígono Industrial El Toll i L'Alberca, Torrent"
-      },
-      createdBy: 'system',
-      active: false,
-      createdAt: new Date('2024-01-07'),
-      updatedAt: new Date('2024-01-07')
-    },
-    {
-      id: '8',
-      code: 'PIC',
-      name: 'Almacén Picanya Principal',
-      location: {
-        lat: 39.4359,
-        lng: -0.4336,
-        address: 'Polígono Industrial Alquería de Moret, Picanya'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-08'),
-      updatedAt: new Date('2024-01-08')
-    },
-    {
-      id: '9',
-      code: 'PA2',
-      name: 'Almacén Paiporta Sur',
-      location: {
-        lat: 39.4234,
-        lng: -0.4147,
-        address: 'Polígono Industrial La Mina, Paiporta'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-09'),
-      updatedAt: new Date('2024-01-09')
-    },
-    {
-      id: '10',
-      code: 'PI2',
-      name: 'Centro Logístico Picanya Sur',
-      location: {
-        lat: 39.4312,
-        lng: -0.4367,
-        address: 'Polígono Industrial Faitanar, Picanya'
-      },
-      createdBy: 'system',
-      active: true,
-      createdAt: new Date('2024-01-10'),
-      updatedAt: new Date('2024-01-10')
-    }
-  ])
-}
+const getWarehouses = async (): Promise<Array<Warehouse>> => WarehouseRepository.getWarehouses()
 
 export const WarehouseController = {
   createWarehouse,

--- a/src/modules/warehouse/warehouse.repository.ts
+++ b/src/modules/warehouse/warehouse.repository.ts
@@ -16,148 +16,150 @@
 import { Warehouse } from './warehouse.model'
 
 // REFACTOR: Remove this mock implementation once the database is connected
-const mockedWarehouses: Warehouse[] = [
-  {
-    id: '1',
-    code: 'PAI',
-    name: 'Almacén Paiporta Principal',
-    location: {
-      lat: 39.4286,
-      lng: -0.4175,
-      address: 'Polígono Industrial La Pascualeta, Paiporta'
+const warehousesObject: Record<'mockedWarehouses', Warehouse[]> = {
+  mockedWarehouses: [
+    {
+      id: '1',
+      code: 'PAI',
+      name: 'Almacén Paiporta Principal',
+      location: {
+        lat: 39.4286,
+        lng: -0.4175,
+        address: 'Polígono Industrial La Pascualeta, Paiporta'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01')
-  },
-  {
-    id: '2',
-    code: 'CAT',
-    name: 'Centro Logístico Catarroja',
-    location: {
-      lat: 39.4036,
-      lng: -0.4027,
-      address: 'Polígono Industrial El Bony, Catarroja'
+    {
+      id: '2',
+      code: 'CAT',
+      name: 'Centro Logístico Catarroja',
+      location: {
+        lat: 39.4036,
+        lng: -0.4027,
+        address: 'Polígono Industrial El Bony, Catarroja'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-02'),
+      updatedAt: new Date('2024-01-02')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-02'),
-    updatedAt: new Date('2024-01-02')
-  },
-  {
-    id: '3',
-    code: 'ALF',
-    name: 'Almacén Alfafar',
-    location: {
-      lat: 39.4225,
-      lng: -0.3775,
-      address: 'Polígono Industrial Rabisancho, Alfafar'
+    {
+      id: '3',
+      code: 'ALF',
+      name: 'Almacén Alfafar',
+      location: {
+        lat: 39.4225,
+        lng: -0.3775,
+        address: 'Polígono Industrial Rabisancho, Alfafar'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-03'),
+      updatedAt: new Date('2024-01-03')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-03'),
-    updatedAt: new Date('2024-01-03')
-  },
-  {
-    id: '4',
-    code: 'SED',
-    name: 'Centro Distribución Sedaví',
-    location: {
-      lat: 39.4256,
-      lng: -0.3839,
-      address: 'Polígono Industrial Sedaví, Av. del Mediterráneo'
+    {
+      id: '4',
+      code: 'SED',
+      name: 'Centro Distribución Sedaví',
+      location: {
+        lat: 39.4256,
+        lng: -0.3839,
+        address: 'Polígono Industrial Sedaví, Av. del Mediterráneo'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-04'),
+      updatedAt: new Date('2024-01-04')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-04'),
-    updatedAt: new Date('2024-01-04')
-  },
-  {
-    id: '5',
-    code: 'ALB',
-    name: 'Almacén Albal Norte',
-    location: {
-      lat: 39.3947,
-      lng: -0.4119,
-      address: 'Polígono Industrial Juan Peris, Albal'
+    {
+      id: '5',
+      code: 'ALB',
+      name: 'Almacén Albal Norte',
+      location: {
+        lat: 39.3947,
+        lng: -0.4119,
+        address: 'Polígono Industrial Juan Peris, Albal'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-05'),
+      updatedAt: new Date('2024-01-05')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-05'),
-    updatedAt: new Date('2024-01-05')
-  },
-  {
-    id: '6',
-    code: 'TOR',
-    name: 'Logística Torrent Mas del Jutge',
-    location: {
-      lat: 39.432,
-      lng: -0.4477,
-      address: 'Polígono Industrial Mas del Jutge, Torrent'
+    {
+      id: '6',
+      code: 'TOR',
+      name: 'Logística Torrent Mas del Jutge',
+      location: {
+        lat: 39.432,
+        lng: -0.4477,
+        address: 'Polígono Industrial Mas del Jutge, Torrent'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-06'),
+      updatedAt: new Date('2024-01-06')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-06'),
-    updatedAt: new Date('2024-01-06')
-  },
-  {
-    id: '7',
-    code: 'TO2',
-    name: 'Centro Logístico Torrent Sur',
-    location: {
-      lat: 39.4173,
-      lng: -0.4594,
-      address: "Polígono Industrial El Toll i L'Alberca, Torrent"
+    {
+      id: '7',
+      code: 'TO2',
+      name: 'Centro Logístico Torrent Sur',
+      location: {
+        lat: 39.4173,
+        lng: -0.4594,
+        address: "Polígono Industrial El Toll i L'Alberca, Torrent"
+      },
+      createdBy: 'system',
+      active: false,
+      createdAt: new Date('2024-01-07'),
+      updatedAt: new Date('2024-01-07')
     },
-    createdBy: 'system',
-    active: false,
-    createdAt: new Date('2024-01-07'),
-    updatedAt: new Date('2024-01-07')
-  },
-  {
-    id: '8',
-    code: 'PIC',
-    name: 'Almacén Picanya Principal',
-    location: {
-      lat: 39.4359,
-      lng: -0.4336,
-      address: 'Polígono Industrial Alquería de Moret, Picanya'
+    {
+      id: '8',
+      code: 'PIC',
+      name: 'Almacén Picanya Principal',
+      location: {
+        lat: 39.4359,
+        lng: -0.4336,
+        address: 'Polígono Industrial Alquería de Moret, Picanya'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-08'),
+      updatedAt: new Date('2024-01-08')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-08'),
-    updatedAt: new Date('2024-01-08')
-  },
-  {
-    id: '9',
-    code: 'PA2',
-    name: 'Almacén Paiporta Sur',
-    location: {
-      lat: 39.4234,
-      lng: -0.4147,
-      address: 'Polígono Industrial La Mina, Paiporta'
+    {
+      id: '9',
+      code: 'PA2',
+      name: 'Almacén Paiporta Sur',
+      location: {
+        lat: 39.4234,
+        lng: -0.4147,
+        address: 'Polígono Industrial La Mina, Paiporta'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-09'),
+      updatedAt: new Date('2024-01-09')
     },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-09'),
-    updatedAt: new Date('2024-01-09')
-  },
-  {
-    id: '10',
-    code: 'PI2',
-    name: 'Centro Logístico Picanya Sur',
-    location: {
-      lat: 39.4312,
-      lng: -0.4367,
-      address: 'Polígono Industrial Faitanar, Picanya'
-    },
-    createdBy: 'system',
-    active: true,
-    createdAt: new Date('2024-01-10'),
-    updatedAt: new Date('2024-01-10')
-  }
-]
+    {
+      id: '10',
+      code: 'PI2',
+      name: 'Centro Logístico Picanya Sur',
+      location: {
+        lat: 39.4312,
+        lng: -0.4367,
+        address: 'Polígono Industrial Faitanar, Picanya'
+      },
+      createdBy: 'system',
+      active: true,
+      createdAt: new Date('2024-01-10'),
+      updatedAt: new Date('2024-01-10')
+    }
+  ]
+}
 
 // const WAREHOUSES_COLLECTION = 'warehouses'
 // const WAREHOUSE_SEQUENCES_COLLECTION = 'warehouse_sequences'
@@ -174,7 +176,9 @@ const createWarehouse = async (warehouse: Warehouse): Promise<Warehouse> => {
 
   console.dir({ method: 'createWarehouse repository', warehouse }, { depth: null })
 
-  mockedWarehouses.push(warehouse)
+  warehousesObject.mockedWarehouses = [...warehousesObject.mockedWarehouses, warehouse]
+
+  console.log('>>>>>>> (createWarehouse) Almacenes almacenados:', warehousesObject.mockedWarehouses.length)
 
   return Promise.resolve(warehouse)
 }
@@ -192,7 +196,9 @@ const getWarehouses = async (): Promise<Array<Warehouse>> => {
 
   // return await storageAdapter.getWarehouses()
 
-  return Promise.resolve(mockedWarehouses)
+  console.log('>>>>>>> (getWarehouses) Almacenes almacenados:', warehousesObject.mockedWarehouses.length)
+
+  return Promise.resolve(warehousesObject.mockedWarehouses)
 }
 
 interface GetWarehousesCreatedTodayByUserIdParams {
@@ -219,7 +225,11 @@ const getWarehousesCreatedTodayByUserId = async ({
   // const querySnapshot = await getDocs(q)
   // return !querySnapshot.empty
 
-  return []
+  return Promise.resolve(
+    warehousesObject.mockedWarehouses.filter(
+      ({ createdBy, createdAt }) => createdBy === userId && createdAt >= start && createdAt <= end
+    )
+  )
 }
 
 const getWarehouseByLocation = async (location: { lat: number; lng: number }): Promise<Warehouse | null> => {


### PR DESCRIPTION
# Description

## 🔄 Context

It's needed to implement a limit of warehouses that a user can create per day. This PR implements that restriction.

## 🎯 Changes

It has been defined the `MAX_AMOUNT_OF_WAREHOUSES_PER_DAY` constant used to control the amount of warehouses created by the same user in a single day.

## 🤔 Why

This limitation protects the platform of possible attacs.

## 🎭 Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 💄 UI/UX update
- [ ] 🏗️ Refactoring
- [ ] 📚 Documentation
- [x] 🔧 Configuration
- [x] 🚀 Enhancement
- [ ] 📦 Other

## 🧪 Testing

Not defined

## 📸 Screenshots

Not defined

## 🚨 Breaking Changes

Not defined

## 📝 Additional Notes

Not defined

## ✅ Checklist

- [x] Code follows project standards
- [x] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] No new warnings generated
- [ ] Breaking changes documented
- [x] Appropriate labels added
